### PR TITLE
Change the event used to change the map dimension (fixes Mystcraft linking books).

### DIFF
--- a/src/main/java/mapwriter/Mw.java
+++ b/src/main/java/mapwriter/Mw.java
@@ -576,19 +576,18 @@ public class Mw {
 	// Event handlers
 	////////////////////////////////
 	
-	public void onWorldLoad(World world) {
-		//MwUtil.log("onWorldLoad: %s, name %s, dimension %d",
-		//		world,
-		//		world.getWorldInfo().getWorldName(),
-		//		world.provider.dimensionId);
-		
-		this.playerDimension = world.provider.dimensionId;
-		if (this.ready) {
-			this.addDimension(this.playerDimension);
-			this.miniMap.view.setDimension(this.playerDimension);
-		}
-	}
-	
+  public void onWorldChange() {
+    //MwUtil.log("onWorldLoad: %s, name %s, dimension %d",
+    //    world,
+    //    world.getWorldInfo().getWorldName(),
+    //    world.provider.dimensionId);
+    this.playerDimension = mc.theWorld.provider.dimensionId;
+    if (this.ready) {
+      this.addDimension(this.playerDimension);
+      this.miniMap.view.setDimension(this.playerDimension);
+    }
+  }
+  
 	public void onWorldUnload(World world) {
 		//MwUtil.log("onWorldUnload: %s, name %s, dimension %d",
 		//		world,

--- a/src/main/java/mapwriter/forge/EventHandler.java
+++ b/src/main/java/mapwriter/forge/EventHandler.java
@@ -2,13 +2,14 @@ package mapwriter.forge;
 
 import mapwriter.Mw;
 import mapwriter.overlay.OverlaySlime;
+import net.minecraft.client.gui.GuiDownloadTerrain;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ChatComponentTranslation;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
+import net.minecraftforge.client.event.GuiOpenEvent;
 import net.minecraftforge.client.event.TextureStitchEvent;
 import net.minecraftforge.event.world.ChunkEvent;
 import net.minecraftforge.event.world.WorldEvent;
-import cpw.mods.fml.client.event.ConfigChangedEvent;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 
 public class EventHandler {
@@ -33,12 +34,13 @@ public class EventHandler {
 		}
 	}
 	
-	@SubscribeEvent
-	public void eventWorldLoad(WorldEvent.Load event){
-		if(event.world.isRemote){
-			this.mw.onWorldLoad(event.world);
-		}
-	}
+  @SubscribeEvent
+  public void eventGuiOpen(GuiOpenEvent event){
+    // Update the dimension when the "Downloading Terrain" screen appears.
+    if(event.gui instanceof GuiDownloadTerrain) {
+      this.mw.onWorldChange();
+    }
+  }
 
     @SubscribeEvent
     public void eventWorldUnload(WorldEvent.Unload event){


### PR DESCRIPTION
This PR changes the way the dimension is changed. It work's by handling the GUI open event and changing the map dimension when the "Downloading Terrain" screen appears. This fixes the dimension of the map changing prematurely when opening Mystcraft linking books, or any mod that uses the LookingGlass library.